### PR TITLE
Bugfix: The user was able to write scripts inside the comment

### DIFF
--- a/src/app/modules/timeline/suggestion/suggestion.component.html
+++ b/src/app/modules/timeline/suggestion/suggestion.component.html
@@ -92,11 +92,12 @@
     (submit)="submit($event)"
   ></app-textfield>
 
+    <br>
     <div class="comment text-left" *ngFor="let com of comments">
       <strong>{{ com.usuario }}</strong>
       <br>
       <div appInnerHtml [content]="com.texto"></div>
-      <br><br><br>
+      <br>
     </div>
 
     <button mat-button class="load-more m-auto text-center" (click)="nextPage()"

--- a/src/app/shared/components/textfield/textfield.component.ts
+++ b/src/app/shared/components/textfield/textfield.component.ts
@@ -96,6 +96,7 @@ export class TextfieldComponent implements AfterViewInit, OnChanges {
   public onInput() {
     if (this.textarea.nativeElement.innerHTML.toUpperCase().includes('SCRIPT')) { // ! NECESSÁRIO PARA SEGURANÇA
       this.textarea.nativeElement.innerHTML = this.textarea.nativeElement.innerHTML.replace(/script/ig, 'sсrірt');
+      // O segundo "script" está escrito com alfabeto cirílico para que perca o efeito, mas pareça igual, NÃO MEXER.
     }
     this.currentLenght = this.textarea.nativeElement.innerText.length;
     if (!this.maxLenght || this.currentLenght <= this.maxLenght) {
@@ -107,6 +108,7 @@ export class TextfieldComponent implements AfterViewInit, OnChanges {
     if (!this.maxLenght || this.currentLenght <= this.maxLenght) {
       if (this.textarea.nativeElement.innerHTML.toUpperCase().includes('SCRIPT')) { // ! NECESSÁRIO PARA SEGURANÇA
         this.textarea.nativeElement.innerHTML = this.textarea.nativeElement.innerHTML.replace(/script/ig, 'sсrірt');
+        // O segundo "script" está escrito com alfabeto cirílico para que perca o efeito, mas pareça igual, NÃO MEXER.
       }
       this.submit.emit(this.textarea.nativeElement.innerHTML);
       this.textarea.nativeElement.innerHTML = '';

--- a/src/app/shared/components/textfield/textfield.component.ts
+++ b/src/app/shared/components/textfield/textfield.component.ts
@@ -68,7 +68,7 @@ export class TextfieldComponent implements AfterViewInit, OnChanges {
     this.fileService.requestAndUpload()
     .subscribe(result => {
       this.toastService.hideSnack();
-      this.appendFile(result.url, result.name)
+      this.appendFile(result.url, result.name);
     });
   }
 
@@ -94,6 +94,9 @@ export class TextfieldComponent implements AfterViewInit, OnChanges {
   }
 
   public onInput() {
+    if (this.textarea.nativeElement.innerHTML.toUpperCase().includes('SCRIPT')) {
+      this.textarea.nativeElement.innerHTML = this.textarea.nativeElement.innerHTML.replace(/script/ig, 'sсrірt');
+    }
     this.currentLenght = this.textarea.nativeElement.innerText.length;
     if (!this.maxLenght || this.currentLenght <= this.maxLenght) {
       this.valueChange.emit(this.textarea.nativeElement.innerHTML);

--- a/src/app/shared/components/textfield/textfield.component.ts
+++ b/src/app/shared/components/textfield/textfield.component.ts
@@ -94,7 +94,7 @@ export class TextfieldComponent implements AfterViewInit, OnChanges {
   }
 
   public onInput() {
-    if (this.textarea.nativeElement.innerHTML.toUpperCase().includes('SCRIPT')) {
+    if (this.textarea.nativeElement.innerHTML.toUpperCase().includes('SCRIPT')) { // ! NECESSÁRIO PARA SEGURANÇA
       this.textarea.nativeElement.innerHTML = this.textarea.nativeElement.innerHTML.replace(/script/ig, 'sсrірt');
     }
     this.currentLenght = this.textarea.nativeElement.innerText.length;
@@ -105,6 +105,9 @@ export class TextfieldComponent implements AfterViewInit, OnChanges {
 
   public onClick() {
     if (!this.maxLenght || this.currentLenght <= this.maxLenght) {
+      if (this.textarea.nativeElement.innerHTML.toUpperCase().includes('SCRIPT')) { // ! NECESSÁRIO PARA SEGURANÇA
+        this.textarea.nativeElement.innerHTML = this.textarea.nativeElement.innerHTML.replace(/script/ig, 'sсrірt');
+      }
       this.submit.emit(this.textarea.nativeElement.innerHTML);
       this.textarea.nativeElement.innerHTML = '';
     }


### PR DESCRIPTION
### Qual era o problema?

> O usuário podia escrever comandos javascript maliciosos dentro dos comentários

### Como ele foi resolvido? 

> O termo "script" (necessário para escrever um código javascript dentro de um HTML) passa a ser automaticamente trocado por "sсrірt" (pode parecer o mesmo, mas não é)

### Qual o resultado esperado? 

> Impossibilidade de executar comandos na caixa de comentários
